### PR TITLE
Remove circular dependency from gemspec

### DIFF
--- a/rjson.gemspec
+++ b/rjson.gemspec
@@ -81,7 +81,6 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<jeweler>, [">= 0"])
-      s.add_runtime_dependency(%q<rjson>, [">= 0"])
       s.add_development_dependency(%q<capybara>, [">= 0"])
       s.add_development_dependency(%q<sqlite3>, [">= 0"])
       s.add_development_dependency(%q<capybara>, [">= 0"])
@@ -96,7 +95,6 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<capybara>, [">= 0"])
     else
       s.add_dependency(%q<jeweler>, [">= 0"])
-      s.add_dependency(%q<rjson>, [">= 0"])
       s.add_dependency(%q<capybara>, [">= 0"])
       s.add_dependency(%q<sqlite3>, [">= 0"])
       s.add_dependency(%q<capybara>, [">= 0"])
@@ -112,7 +110,6 @@ Gem::Specification.new do |s|
     end
   else
     s.add_dependency(%q<jeweler>, [">= 0"])
-    s.add_dependency(%q<rjson>, [">= 0"])
     s.add_dependency(%q<capybara>, [">= 0"])
     s.add_dependency(%q<sqlite3>, [">= 0"])
     s.add_dependency(%q<capybara>, [">= 0"])


### PR DESCRIPTION
rjson can't be installed with the latest bundler because it depends on itself. I've removed these dependencies from the gemspec. I see that the gemspec is managed with Jeweler, but this appears to be a bug in Jeweler, so I updated the gemspec directly.
